### PR TITLE
line items linked to api root

### DIFF
--- a/bangazon/api/serializers/line_item_serializer.py
+++ b/bangazon/api/serializers/line_item_serializer.py
@@ -8,4 +8,4 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = LineItem
-        fields = ('order', 'product','quantity')
+        fields = ('order', 'product', 'quantity')

--- a/bangazon/bangazon/urls.py
+++ b/bangazon/bangazon/urls.py
@@ -10,6 +10,7 @@ router.register(r'orders', OrderViewSet)
 router.register(r'payment_types', PaymentTypeViewSet)
 router.register(r'product_types', ProductTypeViewSet)
 router.register(r'user', UserViewSet)
+router.register(r'line_items', LineItemViewSet)
 
 
 urlpatterns = [


### PR DESCRIPTION
## Description
Line Items can now be accessed through the API.




## Problem to Solve
Users of the API will need to be able to access the LineItem table.

## Changes
```/line_items``` added to urls


## Expected Behavior
"line_items" should be accessable from the api root
