### PR TITLE
added whitelist

### DIFF
--- a/bangazon/bangazon/settings.py
+++ b/bangazon/bangazon/settings.py
@@ -27,6 +27,13 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+CORS_ORIGIN_WHITELIST = [
+    "localhost:8000",
+    "localhost:8080",
+]
+
+
+
 
 # Application definition
 


### PR DESCRIPTION
## Description
This adds localhost:8080 to the CORS allowed domains so that mobile requests to the API are allowed


## Number of Fixes
1. CORS_ORIGIN_WHITELIST property added to settings.py

## Problem to Solve
Mobile requests were running into a CORS error.


## Expected Behavior
Mobile requests coming from localhost:8080 should no longer be denied based on origin
