### PR TITLE
added id field to all serializers

### DIFF
--- a/bangazon/api/serializers/customer_order_serializer.py
+++ b/bangazon/api/serializers/customer_order_serializer.py
@@ -10,4 +10,4 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
       model = CustomerOrder
-      fields = ('active_order', 'customer', 'payment_type', 'line_items', 'url')
+      fields = ('id', 'active_order', 'customer', 'payment_type', 'line_items', 'url')

--- a/bangazon/api/serializers/customer_serializer.py
+++ b/bangazon/api/serializers/customer_serializer.py
@@ -8,4 +8,4 @@ class CustomerSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = Customer
-        fields = ('user', 'street_address', 'city', 'state', 'zip_code', 'url')
+        fields = ('id', 'user', 'street_address', 'city', 'state', 'zip_code', 'url')

--- a/bangazon/api/serializers/line_item_serializer.py
+++ b/bangazon/api/serializers/line_item_serializer.py
@@ -8,4 +8,4 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = LineItem
-        fields = ('order', 'product', 'quantity', 'url')
+        fields = ('id', 'order', 'product', 'quantity', 'url')

--- a/bangazon/api/serializers/payment_type_serializer.py
+++ b/bangazon/api/serializers/payment_type_serializer.py
@@ -10,5 +10,5 @@ class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = PaymentType
-        fields = ('customer', 'card_type', 'billing_name',
+        fields = ('id', 'customer', 'card_type', 'billing_name',
         'card_number','expiration_date', 'cvv', 'url')

--- a/bangazon/api/serializers/product_serializer.py
+++ b/bangazon/api/serializers/product_serializer.py
@@ -8,5 +8,5 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = Product
-        fields = ('seller', 'product_type', 'name',
+        fields = ('id', 'seller', 'product_type', 'name',
         'description','price', 'quantity', 'url' )

--- a/bangazon/api/serializers/product_type_serializer.py
+++ b/bangazon/api/serializers/product_type_serializer.py
@@ -10,4 +10,4 @@ class ProductTypeSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = ProductType
-        fields = ('label', 'url');
+        fields = ('id', 'label', 'url');

--- a/bangazon/api/serializers/user_serializer.py
+++ b/bangazon/api/serializers/user_serializer.py
@@ -9,6 +9,6 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'username', 'email', 'password', 'groups',
+        fields = ('id', 'first_name', 'last_name', 'username', 'email', 'password', 'groups',
                   'is_staff', 'is_active', 'is_superuser', 'last_login',
                   'date_joined', 'url')


### PR DESCRIPTION
## Description
Added 'id' field to every serializer, so that list views have all the info they need to redirect users to their selected detail view.


## Related Ticket(s)
#11 


## Problem to Solve
List views needed access to each object's primary key for providing the appropriate link to detail views.

## Changes
'id' field added to each serializer.

## Expected Behavior
Should work as before but with an extra field included in responses.


## Steps to Test Solution
```
git fetch --all
git checkout origin/sam-PrimaryKeys
python manage.py runserver
```
Browse the API to check that 'id' fields are shown.


## Unit Testing
- [ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [ ] I certify that all existing tests pass

## Documentation

- [ ] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods

## Deploy Notes

No significant changes